### PR TITLE
Enhance PWA for iOS compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,9 @@
     <meta name="author" content="Anson Lai">
     <meta name="theme-color" content="#007bff">
     <link rel="manifest" href="manifest.json">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <link rel="apple-touch-icon" href="icons/icon-192x192.png">
     <style>
         /* --- Global Styles & Variables --- */
         :root {


### PR DESCRIPTION
Adds specific meta tags and an apple-touch-icon link to index.html to improve your "Add to Home Screen" experience on iOS devices.

- Added <meta name="apple-mobile-web-app-capable" content="yes">
- Added <meta name="apple-mobile-web-app-status-bar-style" content="default">
- Added <link rel="apple-touch-icon" href="icons/icon-192x192.png">

manifest.json and service-worker.js were already functional for PWA basics. Existing icons are used as placeholders.