### PR TITLE
Fix: Ensure full group text is shown and group order preserved

### DIFF
--- a/index.html
+++ b/index.html
@@ -2519,17 +2519,20 @@
                 // Group Introduction
                 if (question.group_id && question.group_id !== lastDisplayedGroupId) {
                     const group = quizData.groups.find(g => g.group_id === question.group_id);
-                    if (group && group.introduction) {
-                        groupIntroElement.innerHTML = `<h3>${escapeHtml(group.title || 'Question Group')}</h3><p>${escapeHtml(group.introduction).replace(/\n/g, '<br>')}</p>`;
+                    if (group) {
+                        groupIntroElement.innerHTML = `<h3>${escapeHtml(group.text || 'Question Group')}</h3><p>${escapeHtml(group.intro_text || '').replace(/\n/g, '<br>')}</p>`;
                         groupIntroElement.style.display = 'block';
                     } else {
+                        // Group not found, though group_id was present. Hide intro.
                         groupIntroElement.style.display = 'none';
                     }
                     lastDisplayedGroupId = question.group_id;
-                } else if (!question.group_id && lastDisplayedGroupId !== null) { // Hide if previous was a group
+                } else if (!question.group_id && lastDisplayedGroupId !== null) { 
+                    // Current question has no group, and a group intro was previously displayed
                     groupIntroElement.style.display = 'none';
                     lastDisplayedGroupId = null;
                 }
+                // If question.group_id is the same as lastDisplayedGroupId, do nothing.
 
 
                 // Question Meta Tooltip


### PR DESCRIPTION
This commit addresses issues with the display of grouped questions:

1.  The full introductory text for a question group (`intro_text`) is now correctly displayed above the questions in that group. The group title (`text`) is also displayed.
2.  When the 'Scramble Question Order' option is enabled, questions within a group remain in their specified order and are shuffled as a single unit.

The `renderQuestion` function was updated to fetch and display `group.text` and `group.intro_text`. The `applyFiltersAndStartQuiz` function's logic for handling grouped questions during scrambling was verified to be correct and already met the requirements.