### PR TITLE
feat: Implement subcategory filtering and performance display

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -112,3 +112,113 @@ export async function loadHtmlFragments() {
     // Assuming the existing <div id="quiz-area"></div> will be the container for its dynamic content
     await loadFragment('html/quiz_area.html', 'quiz-area');
 }
+
+export function populateCategorySubcategoryFilter(container, categoriesWithSubcategories) {
+    if (!container) {
+        console.error("Container element not provided for populateCategorySubcategoryFilter.");
+        return;
+    }
+    if (!categoriesWithSubcategories || Object.keys(categoriesWithSubcategories).length === 0) {
+        container.innerHTML = '<p>No categories available.</p>';
+        return;
+    }
+
+    container.innerHTML = ''; // Clear previous options
+
+    Object.entries(categoriesWithSubcategories).forEach(([category, subcategories]) => {
+        const categoryWrapper = document.createElement('div');
+        categoryWrapper.className = 'category-filter-item';
+
+        const mainCategoryLine = document.createElement('div');
+        mainCategoryLine.className = 'main-category-line';
+
+        const categoryCheckbox = document.createElement('input');
+        categoryCheckbox.type = 'checkbox';
+        categoryCheckbox.value = category;
+        categoryCheckbox.name = 'filter-main-category'; // Group main category checkboxes
+        // Sanitize category name for ID: replace spaces and special characters
+        const sanitizedCategoryId = category.replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
+        categoryCheckbox.id = `main-cat-${sanitizedCategoryId}`;
+
+        const categoryLabel = document.createElement('label');
+        categoryLabel.htmlFor = categoryCheckbox.id;
+        // categoryLabel.textContent = ` ${escapeHtml(category)}`; // Text next to checkbox
+
+        const categoryLabelText = document.createElement('span');
+        categoryLabelText.textContent = ` ${escapeHtml(category)}`;
+        categoryLabel.appendChild(categoryLabelText);
+
+
+        const toggleButton = document.createElement('span');
+        toggleButton.className = 'subcategory-toggle';
+        toggleButton.textContent = '[+]';
+        toggleButton.style.cursor = 'pointer';
+        toggleButton.style.marginLeft = '5px';
+        toggleButton.setAttribute('aria-label', `Toggle subcategories for ${escapeHtml(category)}`);
+
+        mainCategoryLine.appendChild(categoryCheckbox);
+        mainCategoryLine.appendChild(categoryLabel); // Label contains the text span now
+        mainCategoryLine.appendChild(toggleButton);
+        categoryWrapper.appendChild(mainCategoryLine);
+
+        const subcategoryList = document.createElement('ul');
+        subcategoryList.className = 'subcategory-list';
+        subcategoryList.style.display = 'none'; // Hidden by default
+        subcategoryList.style.marginLeft = '20px'; // Indent subcategories
+        subcategoryList.setAttribute('aria-labelledby', categoryCheckbox.id);
+
+
+        if (subcategories && subcategories.length > 0) {
+            subcategories.forEach(subcategory => {
+                const subItem = document.createElement('li');
+                const subCheckbox = document.createElement('input');
+                subCheckbox.type = 'checkbox';
+                subCheckbox.value = subcategory;
+                 // Sanitize subcategory and category names for name attribute
+                const sanitizedSubcategoryName = subcategory.replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
+                subCheckbox.name = `filter-subcategory-${sanitizedCategoryId}`; // Unique name per parent
+                subCheckbox.dataset.parentCategory = category;
+                subCheckbox.id = `sub-cat-${sanitizedCategoryId}-${sanitizedSubcategoryName}`;
+
+
+                const subLabel = document.createElement('label');
+                subLabel.htmlFor = subCheckbox.id;
+                // subLabel.appendChild(subCheckbox); // Checkbox inside label for better click handling
+                // subLabel.appendChild(document.createTextNode(` ${escapeHtml(subcategory)}`));
+
+                // Append checkbox first, then text node for spacing
+                subLabel.appendChild(subCheckbox);
+                subLabel.appendChild(document.createTextNode(' ')); // Add space
+                subLabel.appendChild(document.createTextNode(escapeHtml(subcategory)));
+
+
+                subItem.appendChild(subLabel);
+                subcategoryList.appendChild(subItem);
+            });
+        } else {
+            const noSubItem = document.createElement('li');
+            noSubItem.textContent = 'No subcategories';
+            noSubItem.style.fontStyle = 'italic';
+            subcategoryList.appendChild(noSubItem);
+        }
+        categoryWrapper.appendChild(subcategoryList);
+        container.appendChild(categoryWrapper);
+
+        toggleButton.addEventListener('click', (e) => {
+            e.preventDefault(); // Prevent any default action if wrapped in something clickable
+            const isHidden = subcategoryList.style.display === 'none';
+            subcategoryList.style.display = isHidden ? 'block' : 'none';
+            toggleButton.textContent = isHidden ? '[-]' : '[+]';
+            toggleButton.setAttribute('aria-expanded', String(isHidden));
+        });
+
+        // Optional: Clicking main category label also toggles subcategories
+        // categoryLabelText.addEventListener('click', (e) => {
+        //     // Avoid interfering with checkbox click
+        //     if (e.target !== categoryCheckbox) {
+        //        e.preventDefault();
+        //        toggleButton.click(); // Simulate click on the toggle button
+        //     }
+        // });
+    });
+}

--- a/styles/style.css
+++ b/styles/style.css
@@ -1371,3 +1371,108 @@
                 font-size: 1.3rem;
             }
         }
+
+/* Styles for new category/subcategory filter in sidebar */
+.category-filter-item {
+    margin-bottom: 8px; /* Space between main category groups */
+}
+
+.main-category-line {
+    display: flex;
+    align-items: center;
+    padding: 4px 0;
+}
+
+.main-category-line label { /* Label for main category checkbox */
+    display: flex; /* Align checkbox and text */
+    align-items: center;
+    flex-grow: 1; /* Allow label to take available space */
+}
+
+.main-category-line input[type="checkbox"] {
+    margin-right: 6px;
+}
+
+.subcategory-toggle {
+    cursor: pointer;
+    padding: 2px 6px;
+    border: 1px solid #ccc;
+    background-color: #f0f0f0;
+    border-radius: 4px;
+    font-size: 0.9em;
+    margin-left: auto; /* Push toggle to the right */
+    user-select: none; /* Prevent text selection on click */
+}
+
+.subcategory-toggle:hover {
+    background-color: #e0e0e0;
+}
+
+.subcategory-list {
+    list-style-type: none;
+    padding-left: 25px; /* Indentation for subcategories */
+    margin-top: 4px;
+    border-left: 1px dashed #ddd; /* Optional: visual guide for nesting */
+}
+
+.subcategory-list li {
+    padding: 3px 0;
+}
+
+.subcategory-list label { /* Label for subcategory checkbox */
+    display: flex;
+    align-items: center;
+    font-size: 0.95em;
+}
+
+.subcategory-list input[type="checkbox"] {
+    margin-right: 6px;
+}
+
+/* Hide subcategory list by default if JS adds 'display: none;' */
+/* No specific CSS needed for hiding if inline style is used, */
+/* but a class-based approach would be: */
+/* .subcategory-list.hidden { display: none; } */
+
+
+/* Styles for subcategory performance display in modal */
+.subcategory-performance-toggle {
+    background-color: #e7f1ff; /* Light blue background */
+    border: 1px solid #cce0ff;
+    color: #0056b3; /* Darker blue text */
+    padding: 4px 8px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+    margin-left: 10px; /* Space from main category stats */
+    margin-top: 5px; /* Space from main category line if it wraps */
+    display: inline-block; /* Allow margin-top */
+}
+
+.subcategory-performance-toggle:hover {
+    background-color: #d0e0f8;
+}
+
+.subcategory-performance-details {
+    background-color: #fdfdfd; /* Slightly off-white background for details */
+    border: 1px solid #eee;
+    padding: 10px;
+    margin-top: 5px;
+    margin-left: 20px; /* Indent subcategory details */
+    border-radius: 4px;
+}
+
+.subcategory-performance-details ul {
+    list-style-type: none;
+    padding-left: 10px; /* Further indent list items if needed */
+    margin: 0;
+}
+
+.subcategory-performance-details li {
+    padding: 4px 0;
+    font-size: 0.95em;
+    border-bottom: 1px dotted #f0f0f0; /* Separator for subcategory items */
+}
+.subcategory-performance-details li:last-child {
+    border-bottom: none;
+}


### PR DESCRIPTION
This commit introduces the ability for you to filter questions by subcategories and view performance metrics at both the category and subcategory level.

Key changes:

1.  **Data Model:**
    *   Added `mbe_categories_with_subcategories` map to `js/main.js` to define the relationship between categories and their subcategories.
    *   The application now expects question objects in the JSON data to potentially have a `sub_category` field.

2.  **Filtering:**
    *   The sidebar filter for categories has been enhanced. You can now expand main categories to see and select specific subcategories.
    *   `js/ui.js` includes a new `populateCategorySubcategoryFilter` function to render this nested checkbox UI.
    *   `js/main.js`'s `getFilterSettings` function now captures selected main categories and their corresponding selected subcategories.
    *   The `applyFiltersAndStartQuiz` function in `js/main.js` has been updated to apply these hierarchical filter criteria. If a main category is selected, and specific subcategories under it are also selected, only questions matching both will appear. If a main category is selected but no specific subcategories under it are chosen, all questions from that main category are included.

3.  **Performance Dashboard:**
    *   The Performance Dashboard now displays statistics for subcategories.
    *   `calculatePerformanceStats` in `js/main.js` has been modified to compute aggregates for each subcategory.
    *   `displayPerformanceStats` renders main category performance with an accordion-style toggle to show/hide detailed performance metrics for its subcategories.

4.  **Styling:**
    *   Added CSS rules to `styles/style.css` to style the new filter interface elements and the accordion display in the performance modal, ensuring a consistent user experience.